### PR TITLE
Allows grammar input through STDIN

### DIFF
--- a/bin/phpyacc
+++ b/bin/phpyacc
@@ -28,14 +28,16 @@ if (!defined('COMPOSER_INSTALL')) {
 require COMPOSER_INSTALL;
 
 $grammarFile = end($argv);
-$resultFile = substr($grammarFile, 0, -1);
+$isUsingStdin = ($grammarFile === '-');
 
-if ($grammarFile === '-') {
+if ($isUsingStdin) {
     $grammarFile = 'php://stdin';
     $resultFile = 'php://stdout';
+} else {
+    $resultFile = substr($grammarFile, 0, -1);
 }
 
-if ($argc < 2 || !file_exists($grammarFile)) {
+if ($argc < 2 || (!$isUsingStdin && !file_exists($grammarFile))) {
     help();
     exit(4);
 }


### PR DESCRIPTION
Fixes a bug that basically prevented the grammar from being read from STDIN.

The script seemed to allow reading from STDIN, since it explicitly sets `$grammarFile` to `"php://stdin"` if it's equal to `"-"`. However, `"php://stdin"` fails the `file_exists` check that happens shortly after, which causes the script to terminate with exit code 4. This fixes that.