### PR TITLE
Use /usr/bin/env to invoke php

### DIFF
--- a/bin/phpyacc
+++ b/bin/phpyacc
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 namespace PhpYacc;
 


### PR DESCRIPTION
Don’t assume that php must be in `/usr/bin`, use an indirect through `/usr/bin/env`.